### PR TITLE
Modernize project tooling and add Census Explorer navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,52 @@
-docs
+# Build output
+docs/
+
+# Dependencies
+node_modules/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Temporary files
+.tmp/
+temp/
+tmp/
+.cache/
+
+# Coverage / testing
+coverage/
+.nyc_output/
+
+# TypeScript
+*.tsbuildinfo
+
+# Local tooling
+.eslintcache
+
+# Misc
+*.orig
+*.bak

--- a/CONTRIBUTION_BREAKDOWN.md
+++ b/CONTRIBUTION_BREAKDOWN.md
@@ -1,0 +1,755 @@
+# Contribution Breakdown
+
+## Overview
+
+This document summarizes the modernization and Census Explorer work contributed to the HasanAbi Census project in 2026.
+
+The original application concept, census presentation, data work, visual language, SolidJS architecture, Chart.js visualizations, SCSS styling approach, and project direction belong to the original project and its author, **[brilliantdrink](https://github.com/brilliantdrink)**.
+
+This contribution is intended to modernize and extend the existing project without replacing its framework, styling system, charting library, or overall character.
+
+The contribution focuses on:
+
+- dependency and security maintenance
+- local development workflow improvements
+- TypeScript modernization
+- repository hygiene
+- a new Census Explorer navigation shell
+- responsive layout improvements
+- chart sizing fixes
+- accessibility and interaction improvements
+- explicit original-project attribution
+
+During preparation of the upstream pull request, the contribution was reconciled against the latest upstream `main` so the original author's new August 2026 census work and chart fixes remain intact.
+
+---
+
+## 1. Dependency and Security Modernization
+
+The npm dependency tree was reviewed and updated with an emphasis on resolving known vulnerabilities without forcing unnecessary breaking upgrades.
+
+### Work completed
+
+- Audited the existing npm dependency tree.
+- Avoided destructive `npm audit fix --force` behavior.
+- Updated vulnerable or outdated packages to compatible modern versions.
+- Updated the esbuild toolchain.
+- Updated `esbuild-sass-plugin`.
+- Updated compatible SolidJS-related dependencies through the lockfile.
+- Regenerated `package-lock.json`.
+- Re-ran dependency security checks after the updates.
+
+### Result
+
+The dependency audit reached:
+
+```text
+found 0 vulnerabilities
+```
+
+The project remains on the existing SolidJS + esbuild architecture.
+
+---
+
+## 2. Development and Build Workflow Improvements
+
+The project already used a custom esbuild build process. That architecture was kept and extended instead of replacing it with Vite or another bundler.
+
+### Development mode
+
+The custom `build.js` workflow was expanded to support a proper development mode using esbuild's existing APIs.
+
+Added behavior includes:
+
+- esbuild `context()` workflow
+- file watching
+- automatic rebuilds
+- local static serving
+- browser live reload through esbuild's `/esbuild` Server-Sent Events endpoint
+- development source maps
+- development-specific build behavior
+- production-only minification and tree shaking
+- an initial build before serving so the generated application exists before the browser requests it
+
+The local development server runs at:
+
+```text
+http://127.0.0.1:8000
+```
+
+### npm scripts
+
+The project now exposes clear development, build, watch, and type-check commands:
+
+```json
+{
+  "dev": "NODE_ENV=development node build.js",
+  "build": "node build.js",
+  "watch": "NODE_ENV=watch node build.js",
+  "typecheck": "tsc --noEmit"
+}
+```
+
+### Existing architecture intentionally preserved
+
+The contribution continues to use:
+
+- SolidJS
+- esbuild
+- SCSS
+- CSS Modules
+- PostCSS
+- Autoprefixer
+- Chart.js
+- Embla Carousel
+- the existing asset-loader approach
+- the existing generated-site build model
+
+---
+
+## 3. TypeScript Modernization
+
+TypeScript was added as an explicit development dependency and the compiler configuration was modernized for the current SolidJS/esbuild project.
+
+### Compiler configuration improvements
+
+The updated TypeScript configuration includes:
+
+- `ES2020` target
+- `ESNext` modules
+- bundler-style module resolution
+- DOM and iterable DOM libraries
+- SolidJS JSX configuration
+- strict type checking
+- `noImplicitReturns`
+- `isolatedModules`
+- `noEmit`
+- synthetic default import support
+- consistent filename casing enforcement
+- source-only inclusion
+- generated output exclusion
+
+### Asset module declarations
+
+TypeScript declarations were added for asset types already supported by the project's esbuild configuration:
+
+- `.module.scss`
+- `.scss`
+- `.csv`
+- `.svg`
+- `.png`
+- `.jpg`
+- `.webp`
+- `.mp3`
+- `.txt`
+- `.ttf`
+- `.woff`
+- `.woff2`
+
+This aligns TypeScript's module resolution with assets the application already imports successfully at build time.
+
+---
+
+## 4. Repository Hygiene
+
+The repository ignore rules were expanded to cover common local-development artifacts.
+
+Added or clarified ignore coverage includes:
+
+- `node_modules/`
+- environment files
+- logs
+- macOS metadata
+- editor and IDE files
+- temporary directories
+- caches
+- coverage output
+- TypeScript build metadata
+- local tooling caches
+- backup/original files
+
+### Generated `docs/` output
+
+During preparation of the upstream PR, the original author changed upstream behavior so `docs/` is ignored as generated output.
+
+That upstream choice is preserved.
+
+The pull request therefore does **not** include generated `docs/` files.
+
+`package-lock.json` remains tracked for reproducible dependency resolution.
+
+---
+
+## 5. Census Explorer Application Shell
+
+The original full-screen slide presentation was reorganized into a more structured **Census Explorer** interface while retaining the original data visualizations.
+
+The new shell is conceptually:
+
+```text
+┌──────────────────────────────────────────┐
+│ Explorer Header                          │
+├──────────────────────────────────────────┤
+│                                          │
+│ Home / Census Visualization              │
+│                                          │
+├──────────────────────────────────────────┤
+│ Horizontal Category Navigation           │
+├──────────────────────────────────────────┤
+│ Original Project Attribution Footer      │
+└──────────────────────────────────────────┘
+```
+
+The charting system itself remains Chart.js-based and continues to use the existing census datasets and presentation logic.
+
+---
+
+## 6. Stable Census Category Model
+
+The slide registry was expanded so each census category has a stable machine-readable identifier in addition to its display name.
+
+Current identifiers include:
+
+```text
+home
+age
+gender
+political-ideology
+ethnicity
+religion
+sexuality
+height
+trans-chatters
+location
+salary
+education
+vcard
+weebs
+diet
+neurodiversity
+gayming-frogs
+years-watched
+political-activism
+housing
+discovery
+```
+
+This provides a cleaner basis for:
+
+- navigation state
+- category synchronization
+- future URL state
+- future view switching
+- future comparisons
+
+### Cover renamed to Home
+
+The navigation label formerly presented as:
+
+```text
+Cover
+```
+
+is now:
+
+```text
+Home
+```
+
+The internal identifier was also changed to `home` rather than retaining an obsolete `cover` slug.
+
+---
+
+## 7. Explorer Header
+
+A persistent application header was added.
+
+The header includes:
+
+- the original HasanAbi Census title artwork
+- Home navigation through the title/logo
+- the current census category control
+- the current visualization-mode indicator
+- responsive behavior at narrower widths
+
+The existing title SVG is reused rather than introducing replacement branding.
+
+---
+
+## 8. Custom Category Dropdown
+
+The native browser category `<select>` was replaced with a custom SolidJS dropdown so its appearance and placement can match the Census Explorer interface.
+
+### Behavior
+
+The custom dropdown:
+
+- opens directly below the category control
+- uses the project's dark visual style
+- displays all census categories
+- highlights the current category
+- updates the main visualization carousel
+- closes after selection
+- closes when clicking outside
+- closes with `Escape`
+- exposes expanded/menu state through ARIA attributes
+- remains usable on narrower screens
+
+This removes platform-dependent native select rendering while keeping the control keyboard-accessible.
+
+---
+
+## 9. Horizontal Category Rail
+
+The original large wrapped category navigation was replaced with a horizontal category rail.
+
+The new rail:
+
+- stays on a single horizontal row
+- uses the project's existing Embla Carousel dependency
+- supports drag/swipe interaction
+- includes previous/next rail controls
+- synchronizes with the active census slide
+- scrolls toward the currently selected category
+- highlights the active category
+- remains usable on mobile-width layouts
+- reads from the same centralized census category registry as the header
+
+### Navigation roles
+
+The interface now provides two complementary category-navigation methods.
+
+**Header dropdown**
+
+Useful for jumping directly to a known category.
+
+**Horizontal category rail**
+
+Useful for sequential browsing and discovering adjacent categories.
+
+---
+
+## 10. Main Carousel Refactor
+
+The original `Slider` component previously owned several overlapping navigation systems.
+
+It handled:
+
+- the primary visualization carousel
+- desktop category navigation
+- mobile category navigation
+- mobile expansion/collapse behavior
+- multiple carousel instances
+- keyboard navigation
+- visualization arrow controls
+
+The component was simplified around the Explorer shell.
+
+It now primarily owns:
+
+- selected slide state
+- previous/next state
+- synchronization with the header
+- synchronization with the category rail
+- left/right visualization navigation
+- keyboard navigation
+
+The old wrapped desktop navigation and separate vertical mobile navigation were replaced by the shared responsive category rail.
+
+---
+
+## 11. Existing Visualization Behavior Preserved
+
+The Explorer work intentionally does not replace the existing census chart system.
+
+Preserved behavior includes:
+
+- Chart.js stacked bar charts
+- census data files
+- chart labels
+- chart colors
+- census date ordering
+- data labels
+- tooltips
+- chart notes
+- Home presentation
+- previous/next category navigation
+- swipe/drag navigation
+- keyboard category navigation
+
+The initial Explorer phase changes application structure and navigation rather than redefining the census data.
+
+---
+
+## 12. Visualization Layout and Sizing Fixes
+
+The original visualization layout assumed that the chart effectively owned the entire browser viewport.
+
+After adding the Explorer header, category rail, and footer, that assumption caused oversized charts and content clipping.
+
+Observed symptoms included:
+
+- chart titles being pushed under the top header
+- legends consuming too much vertical space
+- visualization content being clipped
+- charts overflowing the actual visualization area
+
+### Legacy bottom-navigation spacing removed
+
+The original slide styles reserved fixed bottom space for the previous navigation system.
+
+That fixed spacing became obsolete once the category rail received its own application-grid row.
+
+The old fixed bottom offset was removed.
+
+### Container-aware chart sizing
+
+`BarChartSlide` was updated so chart dimensions are derived from the actual available visualization container rather than the full browser viewport.
+
+A `ResizeObserver` measures the remaining chart area.
+
+The layout now behaves conceptually as:
+
+```text
+Visualization Row
+│
+├── Category title
+├── Optional note
+│
+└── Remaining available space
+    └── Chart
+```
+
+Chart sizing therefore accounts for:
+
+- the top Explorer header
+- the chart title
+- optional chart notes
+- the horizontal category rail
+- the footer
+- browser resizing
+
+---
+
+## 13. Responsive Header Improvements
+
+The compact-header breakpoint was adjusted so desktop controls do not remain active at widths where they no longer fit.
+
+At narrower widths:
+
+- redundant control labels can be hidden
+- the selected category remains visible
+- the View control can be hidden where necessary
+- the title/logo uses a smaller footprint
+- the category dropdown remains accessible
+
+This prevents the header controls from clipping or extending beyond the viewport.
+
+---
+
+## 14. Keyboard and Interaction Safety
+
+Keyboard category navigation remains available for the primary visualization carousel.
+
+Global navigation handling was also tightened so interacting with form controls or buttons does not unexpectedly trigger carousel navigation.
+
+Interactive elements such as buttons, inputs, and selectors are excluded from global left/right navigation where appropriate.
+
+---
+
+## 15. Original Project Attribution Footer
+
+A dedicated footer was added beneath the category navigation.
+
+It credits the original project:
+
+```text
+Original project by @brilliantdrink
+```
+
+and links to the original author's GitHub profile.
+
+This keeps original authorship visible after the interface restructuring.
+
+---
+
+## 16. Upstream 2026 Work Preserved During Reconciliation
+
+The upstream pull-request branch was created from the latest original-project `main` and this contribution was applied on top of it.
+
+The following upstream work was explicitly preserved rather than overwritten.
+
+### August 2026 census data
+
+The original author's latest August 2026 census update remains the source of truth.
+
+### Ethnicity source update
+
+Upstream replaced the previous `race.csv` source with:
+
+```text
+ethnicity.csv
+```
+
+The Explorer category model uses the new upstream ethnicity source.
+
+### Age category/color changes
+
+The upstream `colorsAge` changes remain enabled for the Age visualization.
+
+### New 2026 categories
+
+The following upstream categories were added to the Explorer registry:
+
+```text
+Political Activism
+Housing
+Discovery
+```
+
+They use stable Explorer IDs:
+
+```text
+political-activism
+housing
+discovery
+```
+
+### Chart normalization / scale fixes
+
+The original author's latest Chart.js stacked-scale changes remain untouched by this contribution.
+
+The PR branch is based on the upstream version containing the latest 0–100% scale correction.
+
+### Data ownership
+
+This contribution does not claim authorship of the new August 2026 census data or the new polls.
+
+Those changes originate from the upstream project and are preserved so the Explorer UI works with the current project state.
+
+---
+
+## 17. Files Added by This Contribution
+
+New application components include:
+
+```text
+src/components/ExplorerHeader/
+├── ExplorerHeader.tsx
+└── explorerHeader.module.scss
+
+src/components/CategoryRail/
+├── CategoryRail.tsx
+└── categoryRail.module.scss
+
+src/components/ProjectFooter/
+├── ProjectFooter.tsx
+└── projectFooter.module.scss
+
+src/types/
+└── assets.d.ts
+```
+
+This documentation file is also intentionally included:
+
+```text
+CONTRIBUTION_BREAKDOWN.md
+```
+
+---
+
+## 18. Existing Files Significantly Updated
+
+The modernization and Explorer work changes files including:
+
+```text
+.gitignore
+build.js
+package.json
+package-lock.json
+tsconfig.json
+
+src/components/Slider/Slider.tsx
+src/components/Slider/slider.module.scss
+
+src/components/Slide/slideData.tsx
+src/components/Slide/BarChartSlide.tsx
+src/components/Slide/slide.module.scss
+```
+
+Generated `docs/` output is intentionally excluded from the upstream pull request.
+
+---
+
+## 19. Validation Performed
+
+The contribution has been validated with:
+
+```bash
+npm run typecheck
+npm run build
+npm run dev
+```
+
+The TypeScript compiler and production esbuild build have completed successfully.
+
+Dependency security validation also reached:
+
+```text
+found 0 vulnerabilities
+```
+
+Before the upstream PR commit, the reconciled branch also passed:
+
+```bash
+git diff --cached --check
+npm run typecheck
+npm run build
+```
+
+Visual testing during development included:
+
+- Home
+- census chart slides
+- the Height slide and category-change note
+- Explorer header
+- custom category dropdown
+- horizontal category rail
+- responsive resizing
+- medium-width layouts
+- chart-title/layout behavior after the Explorer-shell refactor
+
+---
+
+## 20. Design Principles Followed
+
+The modernization intentionally respects the original project's technology and design decisions.
+
+### Preserved
+
+- SolidJS
+- SCSS
+- CSS Modules
+- esbuild
+- Chart.js
+- Embla Carousel
+- existing fonts
+- existing title artwork
+- existing census presentation
+- current upstream census data
+
+### Deliberately not introduced
+
+The contribution does **not** migrate the project to:
+
+- React
+- Next.js
+- Vite
+- Tailwind CSS
+- shadcn
+- a new router
+- a replacement charting library
+
+The purpose is to improve the existing project rather than replace its implementation style.
+
+---
+
+## 21. Current Explorer State
+
+The application currently supports:
+
+```text
+Home
+  ↓
+Census category selection
+  ↓
+Snapshot visualization
+  ↓
+Horizontal browsing
+```
+
+The current visualization mode remains:
+
+```text
+Snapshot
+```
+
+This corresponds to the existing stacked census charts.
+
+---
+
+## 22. Planned / Not Yet Implemented
+
+The following ideas are possible future work and are **not** part of this contribution.
+
+### Trend View
+
+A time-series view showing how a response changes across census dates.
+
+### Change View
+
+A visualization focused on percentage-point movement between two census periods.
+
+### Compare View
+
+A richer comparison interface between selected census periods or categories.
+
+### Timeline Scrubber
+
+Interactive selection of census dates.
+
+### Biggest Movers
+
+Automatic summaries of the largest increases and decreases between selected census periods.
+
+### URL Navigation
+
+Stable category/view URLs such as:
+
+```text
+#sexuality/snapshot
+#sexuality/trend
+```
+
+No router has been added as part of this contribution.
+
+---
+
+## 23. Contribution Summary
+
+This contribution:
+
+- modernizes and secures the dependency tree
+- adds a practical local development workflow
+- adds strict TypeScript validation
+- adds asset declarations for TypeScript
+- improves repository hygiene
+- preserves the existing SolidJS/esbuild/SCSS architecture
+- introduces stable category identifiers
+- renames Cover to Home
+- adds a persistent Census Explorer header
+- adds a custom category dropdown
+- replaces wrapped category navigation with a horizontal rail
+- reorganizes the application into an Explorer shell
+- adds original-project attribution
+- removes legacy layout assumptions
+- makes chart sizing responsive to the actual visualization container
+- improves responsive header behavior
+- preserves current upstream census data and chart behavior
+- integrates the upstream Political Activism, Housing, and Discovery categories into the Explorer model
+- preserves the latest upstream ethnicity, age-color, and Chart.js scale changes
+- establishes a foundation for future Trend, Change, Compare, and URL-state features
+
+---
+
+## Attribution
+
+Original HasanAbi Census project, census data work, visual design, and core visualization concept:
+
+**[brilliantdrink](https://github.com/brilliantdrink)**
+
+Modernization, security updates, development workflow improvements, TypeScript work, responsive layout work, and Census Explorer interface changes:
+
+**Tyler Smith / Atlessc**
+
+This document is included to make the boundaries between original upstream work, preserved upstream updates, and this contribution explicit.

--- a/build.js
+++ b/build.js
@@ -1,20 +1,29 @@
 import fs from 'fs'
 import path from 'path'
 import * as esbuild from 'esbuild'
-import {sassPlugin} from 'esbuild-sass-plugin'
+import { sassPlugin } from 'esbuild-sass-plugin'
 import postcss from 'postcss'
 import autoprefixer from 'autoprefixer'
 import postcssModules from 'postcss-modules'
-import {solidPlugin} from 'esbuild-plugin-solid'
-const packageJson = (await import('./package.json', {with: { type: 'json' }})).default
+import { solidPlugin } from 'esbuild-plugin-solid'
+
+const packageJson = (
+  await import('./package.json', { with: { type: 'json' } })
+).default
+
+const isDev = process.env.NODE_ENV === 'development'
+const isWatch = process.env.NODE_ENV === 'watch'
+const isDevelopmentBuild = isDev || isWatch
 
 const config = {
   entryPoints: ['src/index.tsx'],
   bundle: true,
   jsx: 'automatic',
+
   define: {
-    'VERSION': JSON.stringify(packageJson.version),
+    VERSION: JSON.stringify(packageJson.version),
   },
+
   loader: {
     '.ttf': 'file',
     '.woff': 'file',
@@ -27,61 +36,135 @@ const config = {
     '.txt': 'file',
     '.csv': 'file',
   },
+
   outdir: 'docs',
-  minify: process.env.NODE_ENV !== 'watch',
-  treeShaking: process.env.NODE_ENV !== 'watch',
-  sourcemap: process.env.NODE_ENV === 'watch' ? 'inline' : false,
+
+  minify: !isDevelopmentBuild,
+  treeShaking: !isDevelopmentBuild,
+  sourcemap: isDevelopmentBuild ? 'inline' : false,
+
   plugins: [
     solidPlugin(),
+
     sassPlugin({
       filter: /\.module\.scss$/,
       async transform(source, _, from) {
-        let cssModule;
-        const {css} = (await postcss(autoprefixer, postcssModules({
-          getJSON: (_, json) => cssModule = JSON.stringify(json, null, 2)
-        })).process(source, {from}))
+        let cssModule
+
+        const { css } = await postcss(
+          autoprefixer,
+          postcssModules({
+            getJSON: (_, json) => {
+              cssModule = JSON.stringify(json, null, 2)
+            },
+          }),
+        ).process(source, { from })
+
         return {
           contents: css,
-          pluginData: {exports: cssModule},
-          loader: 'js'
+          pluginData: {
+            exports: cssModule,
+          },
+          loader: 'js',
         }
       },
     }),
+
     sassPlugin({
       filter: /\.scss$/,
       async transform(source, _, from) {
-        return (await postcss(autoprefixer).process(source, {from})).css
+        return (
+          await postcss(autoprefixer).process(source, {
+            from,
+          })
+        ).css
       },
     }),
+
     {
       name: 'html-file',
+
       setup(build) {
         build.onEnd((result) => {
-          const css = fs.readFileSync(path.join(build.initialOptions.outdir, 'index.css'), 'utf8')
-          let html = `\
+          if (result.errors.length > 0) {
+            return
+          }
+
+          const outdir = build.initialOptions.outdir
+
+          if (!outdir) {
+            return
+          }
+
+          const cssPath = path.join(outdir, 'index.css')
+
+          if (!fs.existsSync(cssPath)) {
+            return
+          }
+
+          const css = fs.readFileSync(cssPath, 'utf8')
+
+          const liveReloadScript = isDev
+            ? `
+    <script>
+      new EventSource('/esbuild').addEventListener('change', () => {
+        location.reload()
+      })
+    </script>`
+            : ''
+
+          const html = `\
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The HasanAbi Census</title>
-    <script src="index.js" defer></script>
+    <script src="index.js" defer></script>${liveReloadScript}
     <style>${css}</style>
 </head>
 <body>
-    <div id="app">
-    </div>
+    <div id="app"></div>
 </body>
 </html>
 `
-          fs.writeFileSync(path.join(build.initialOptions.outdir, 'index.html'), html, 'utf8')
+
+          fs.writeFileSync(
+            path.join(outdir, 'index.html'),
+            html,
+            'utf8',
+          )
         })
       },
     },
   ],
 }
 
-if (process.env.NODE_ENV === 'watch')
-  await (await esbuild.context(config)).watch({})
-else
+if (isDev) {
+  const context = await esbuild.context(config)
+
+  // Ensure docs/index.html exists before the browser makes its first request.
+  await context.rebuild()
+
+  await context.watch()
+
+  const { hosts, port } = await context.serve({
+    servedir: 'docs',
+    host: '127.0.0.1',
+    port: 8000,
+  })
+
+  console.log('')
+  console.log('HasanAbi Census dev server running:')
+  console.log(`http://${hosts[0]}:${port}`)
+  console.log('')
+} else if (isWatch) {
+  const context = await esbuild.context(config)
+
+  await context.rebuild()
+  await context.watch()
+
+  console.log('Watching for changes...')
+} else {
   await esbuild.build(config)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,9 @@
         "classnames": "^2.5.1",
         "csv-parse": "^5.5.6",
         "embla-carousel-solid": "^8.2.0",
-        "esbuild": "^0.23.1",
+        "esbuild": "^0.28.2",
         "esbuild-plugin-solid": "^0.6.0",
-        "esbuild-sass-plugin": "^3.3.1",
+        "esbuild-sass-plugin": "^3.7.0",
         "lodash.clonedeep": "^4.5.0",
         "postcss": "^8.4.41",
         "postcss-modules": "^6.0.0",
@@ -28,60 +28,49 @@
         "solid-js": "^1.8.21"
       },
       "devDependencies": {
-        "@types/lodash.clonedeep": "^4.5.9"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+        "@types/lodash.clonedeep": "^4.5.9",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
-      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
-      "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/helper-compilation-targets": "^7.25.2",
-        "@babel/helper-module-transforms": "^7.25.2",
-        "@babel/helpers": "^7.25.0",
-        "@babel/parser": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.2",
-        "@babel/types": "^7.25.2",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -97,15 +86,16 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.5.tgz",
-      "integrity": "sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.4",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -124,14 +114,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
-      "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
-        "@babel/helper-validator-option": "^7.24.8",
-        "browserslist": "^4.23.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -160,6 +150,15 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
@@ -174,28 +173,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -269,67 +267,52 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.4.tgz",
-      "integrity": "sha512-nq+eWrOgdtu3jG5Os4TQP3x3cLA8hR8TvJNjD8vnPa20WGycimcparWnLK4jJhElTK6SDyuJo1weMKO/5LpmLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.4"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -424,62 +407,61 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.4.tgz",
-      "integrity": "sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.4",
-        "@babel/parser": "^7.25.4",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.4",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.4.tgz",
-      "integrity": "sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
-      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
       "cpu": [
         "ppc64"
       ],
@@ -493,9 +475,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
       "cpu": [
         "arm"
       ],
@@ -509,9 +491,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
       "cpu": [
         "arm64"
       ],
@@ -525,9 +507,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
       "cpu": [
         "x64"
       ],
@@ -541,9 +523,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
       "cpu": [
         "arm64"
       ],
@@ -557,9 +539,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
       "cpu": [
         "x64"
       ],
@@ -573,9 +555,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
       "cpu": [
         "arm64"
       ],
@@ -589,9 +571,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
       "cpu": [
         "x64"
       ],
@@ -605,9 +587,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
       "cpu": [
         "arm"
       ],
@@ -621,9 +603,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
       "cpu": [
         "arm64"
       ],
@@ -637,9 +619,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
       "cpu": [
         "ia32"
       ],
@@ -653,9 +635,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
       "cpu": [
         "loong64"
       ],
@@ -669,9 +651,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
       "cpu": [
         "mips64el"
       ],
@@ -685,9 +667,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
       "cpu": [
         "ppc64"
       ],
@@ -701,9 +683,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
       "cpu": [
         "riscv64"
       ],
@@ -717,9 +699,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
       "cpu": [
         "s390x"
       ],
@@ -733,9 +715,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
       "cpu": [
         "x64"
       ],
@@ -748,10 +730,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
       "cpu": [
         "x64"
       ],
@@ -765,9 +763,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
       "cpu": [
         "arm64"
       ],
@@ -781,9 +779,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
       "cpu": [
         "x64"
       ],
@@ -796,10 +794,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
       "cpu": [
         "x64"
       ],
@@ -813,9 +827,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
       "cpu": [
         "arm64"
       ],
@@ -829,9 +843,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
       "cpu": [
         "ia32"
       ],
@@ -845,9 +859,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "cpu": [
         "x64"
       ],
@@ -861,17 +875,23 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -883,25 +903,16 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -913,6 +924,281 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==",
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/@solid-primitives/event-listener": {
       "version": "2.4.5",
@@ -1006,31 +1292,6 @@
         "@types/lodash": "*"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -1108,34 +1369,22 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1152,10 +1401,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1163,13 +1413,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/buffer-builder": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
-      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
-      "license": "MIT/X11",
-      "peer": true
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001810",
@@ -1190,20 +1433,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/chart.js": {
       "version": "4.4.4",
@@ -1227,27 +1456,18 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/classnames": {
@@ -1256,20 +1476,16 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+    "node_modules/colorjs.io": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+      "integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
       "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/color"
       }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1318,10 +1534,20 @@
         }
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.13",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
-      "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -1352,10 +1578,19 @@
         "solid-js": "^1.0.0"
       }
     },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1365,30 +1600,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
       }
     },
     "node_modules/esbuild-plugin-solid": {
@@ -1407,48 +1644,26 @@
       }
     },
     "node_modules/esbuild-sass-plugin": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.3.1.tgz",
-      "integrity": "sha512-SnO1ls+d52n6j8gRRpjexXI8MsHEaumS0IdDHaYM29Y6gakzZYMls6i9ql9+AWMSQk/eryndmUpXEgT34QrX1A==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-3.7.0.tgz",
+      "integrity": "sha512-vxNSXFx3/0ZFApKo9036ek2iRfsT+yVO99qIYqa+JaDSuJuId2/N4s1TY+xfK+5LRpAMQkfdBVUTxb/1r2bq1A==",
       "license": "MIT",
       "dependencies": {
-        "resolve": "^1.22.8",
-        "safe-identifier": "^0.4.2",
-        "sass": "^1.71.1"
+        "resolve": "^1.22.11",
+        "sass": "^1.97.3"
       },
       "peerDependencies": {
-        "esbuild": ">=0.20.1",
-        "sass-embedded": "^1.71.1"
+        "esbuild": ">=0.27.3",
+        "sass-embedded": "^1.97.3"
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fraction.js": {
@@ -1462,20 +1677,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1505,40 +1706,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1566,30 +1737,18 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1603,6 +1762,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1612,20 +1772,12 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/js-tokens": {
@@ -1635,15 +1787,15 @@
       "license": "MIT"
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json5": {
@@ -1695,9 +1847,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1712,19 +1864,20 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
-      "license": "MIT"
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+    "node_modules/node-releases": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
       }
     },
     "node_modules/normalize-range": {
@@ -1743,27 +1896,28 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1780,9 +1934,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -1886,108 +2040,132 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
       "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
       "bin": {
         "resolve": "bin/resolve"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-identifier": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
-      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
-      "license": "ISC"
-    },
     "node_modules/sass": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
-      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.103.1.tgz",
+      "integrity": "sha512-9icZURbP51S6S0QGoyaeqk9uB06GNWxsFYWfH5RgpFgqK5FA8tJcM3AdVxrZEVJ7dz+L87nG95gBKf4VuaMHGw==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
-        "immutable": "^4.0.0",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/sass-embedded": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.77.8.tgz",
-      "integrity": "sha512-WGXA6jcaoBo5Uhw0HX/s6z/sl3zyYQ7ZOnLOJzqwpctFcFmU4L07zn51e2VSkXXFpQZFAdMZNqOGz/7h/fvcRA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.103.1.tgz",
+      "integrity": "sha512-UVIuFZPzz+4DXYbHzQ5gKaKkyP2IH3Sc/WoF63N2V7QIfnC2E9UpQAtiKlCVJTfBe43HRgHDBLnXpZkYAEBsNQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@bufbuild/protobuf": "^1.0.0",
-        "buffer-builder": "^0.2.0",
-        "immutable": "^4.0.0",
+        "@bufbuild/protobuf": "^2.5.0",
+        "colorjs.io": "^0.7.0",
+        "immutable": "^5.1.5",
         "rxjs": "^7.4.0",
         "supports-color": "^8.1.1",
+        "sync-child-process": "^1.0.2",
         "varint": "^6.0.0"
       },
+      "bin": {
+        "sass": "dist/bin/sass.js"
+      },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20.19.0"
       },
       "optionalDependencies": {
-        "sass-embedded-android-arm": "1.77.8",
-        "sass-embedded-android-arm64": "1.77.8",
-        "sass-embedded-android-ia32": "1.77.8",
-        "sass-embedded-android-x64": "1.77.8",
-        "sass-embedded-darwin-arm64": "1.77.8",
-        "sass-embedded-darwin-x64": "1.77.8",
-        "sass-embedded-linux-arm": "1.77.8",
-        "sass-embedded-linux-arm64": "1.77.8",
-        "sass-embedded-linux-ia32": "1.77.8",
-        "sass-embedded-linux-musl-arm": "1.77.8",
-        "sass-embedded-linux-musl-arm64": "1.77.8",
-        "sass-embedded-linux-musl-ia32": "1.77.8",
-        "sass-embedded-linux-musl-x64": "1.77.8",
-        "sass-embedded-linux-x64": "1.77.8",
-        "sass-embedded-win32-arm64": "1.77.8",
-        "sass-embedded-win32-ia32": "1.77.8",
-        "sass-embedded-win32-x64": "1.77.8"
+        "sass-embedded-all-unknown": "1.103.1",
+        "sass-embedded-android-arm": "1.103.1",
+        "sass-embedded-android-arm64": "1.103.1",
+        "sass-embedded-android-riscv64": "1.103.1",
+        "sass-embedded-android-x64": "1.103.1",
+        "sass-embedded-darwin-arm64": "1.103.1",
+        "sass-embedded-darwin-x64": "1.103.1",
+        "sass-embedded-linux-arm": "1.103.1",
+        "sass-embedded-linux-arm64": "1.103.1",
+        "sass-embedded-linux-musl-arm": "1.103.1",
+        "sass-embedded-linux-musl-arm64": "1.103.1",
+        "sass-embedded-linux-musl-riscv64": "1.103.1",
+        "sass-embedded-linux-musl-x64": "1.103.1",
+        "sass-embedded-linux-riscv64": "1.103.1",
+        "sass-embedded-linux-x64": "1.103.1",
+        "sass-embedded-unknown-all": "1.103.1",
+        "sass-embedded-win32-arm64": "1.103.1",
+        "sass-embedded-win32-x64": "1.103.1"
+      }
+    },
+    "node_modules/sass-embedded-all-unknown": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-all-unknown/-/sass-embedded-all-unknown-1.103.1.tgz",
+      "integrity": "sha512-MwX2ap06TbImAqlbnH6EndgBBejk6Eq2QB6Ae2hukCn9wmXf9cRu27um3mz3tyB4oJOOku0xfHqFH/+ckYj6YA==",
+      "cpu": [
+        "!arm",
+        "!arm64",
+        "!riscv64",
+        "!x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "sass": "1.103.1"
       }
     },
     "node_modules/sass-embedded-android-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.77.8.tgz",
-      "integrity": "sha512-GpGL7xZ7V1XpFbnflib/NWbM0euRzineK0iwoo31/ntWKAXGj03iHhGzkSiOwWSFcXgsJJi3eRA5BTmBvK5Q+w==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm/-/sass-embedded-android-arm-1.103.1.tgz",
+      "integrity": "sha512-p36WHpsu5HEo2+NVNbI2Nmb8VgVH0xwOQyzghvZhF7ikGCzEVYI5BP28vHUZlCcgj2TUvMEJKI2lV336a+F/sg==",
       "cpu": [
         "arm"
       ],
@@ -1997,17 +2175,14 @@
         "android"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.77.8.tgz",
-      "integrity": "sha512-EmWHLbEx0Zo/f/lTFzMeH2Du+/I4RmSRlEnERSUKQWVp3aBSO04QDvdxfFezgQ+2Yt/ub9WMqBpma9P/8MPsLg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.103.1.tgz",
+      "integrity": "sha512-jBXWMksyz55XeLOWvQs64BqiG5DcqflmMxcvMoA2oHtQT/7XZ02hBn502qpcF/q8Qd+qqG/hU5ccM+hGXrbQZw==",
       "cpu": [
         "arm64"
       ],
@@ -2017,19 +2192,16 @@
         "android"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-android-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.77.8.tgz",
-      "integrity": "sha512-+GjfJ3lDezPi4dUUyjQBxlNKXNa+XVWsExtGvVNkv1uKyaOxULJhubVo2G6QTJJU0esJdfeXf5Ca5/J0ph7+7w==",
+    "node_modules/sass-embedded-android-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-riscv64/-/sass-embedded-android-riscv64-1.103.1.tgz",
+      "integrity": "sha512-rzrH7RNntk0rx+zCE9xOiAIUt37D1cQKvFfcoX0xiePdGbNHBN8DWKaWN9vaCRfbgKCmxPjevzaqFNI/G/8E1A==",
       "cpu": [
-        "ia32"
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
@@ -2037,17 +2209,14 @@
         "android"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-android-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.77.8.tgz",
-      "integrity": "sha512-YZbFDzGe5NhaMCygShqkeCWtzjhkWxGVunc7ULR97wmxYPQLPeVyx7XFQZc84Aj0lKAJBJS4qRZeqphMqZEJsQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-android-x64/-/sass-embedded-android-x64-1.103.1.tgz",
+      "integrity": "sha512-EQglAJXJutuIcqgZf7YOwzao2ND6ow/OgqN+cM48/Qaeb6AimYmZiUJmM9FFcmS3Q2n1k6/2OU3l3Hlin7bFpw==",
       "cpu": [
         "x64"
       ],
@@ -2057,17 +2226,14 @@
         "android"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.77.8.tgz",
-      "integrity": "sha512-aifgeVRNE+i43toIkDFFJc/aPLMo0PJ5s5hKb52U+oNdiJE36n65n2L8F/8z3zZRvCa6eYtFY2b7f1QXR3B0LA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.103.1.tgz",
+      "integrity": "sha512-rlaBeCul8pLbDRKdBAxdDxSBwFU5fbX42ci6CxW2Vbs34jWTMQ72+nE2v2KkGGce+JnYbb7UV6xDP/4uDWWi+w==",
       "cpu": [
         "arm64"
       ],
@@ -2077,17 +2243,14 @@
         "darwin"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-darwin-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.77.8.tgz",
-      "integrity": "sha512-/VWZQtcWIOek60Zj6Sxk6HebXA1Qyyt3sD8o5qwbTgZnKitB1iEBuNunyGoAgMNeUz2PRd6rVki6hvbas9hQ6w==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.103.1.tgz",
+      "integrity": "sha512-VSKFfhI//AOct6ppFmAaSH7tlW2LOFECMGs77jIoWf0ZjvGch/3sc9lUTTdIaYIOnTS4qpZck+8OcI2D0G92QA==",
       "cpu": [
         "x64"
       ],
@@ -2097,17 +2260,14 @@
         "darwin"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.77.8.tgz",
-      "integrity": "sha512-2edZMB6jf0whx3T0zlgH+p131kOEmWp+I4wnKj7ZMUeokiY4Up05d10hSvb0Q63lOrSjFAWu6P5/pcYUUx8arQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.103.1.tgz",
+      "integrity": "sha512-tJRLPUtBwXHTnBnG7I39gQvCLreuOHLLCMyKHPR1hQ7aFNwiZjADYzKMRQPNMUqti/Os9z+6I7V13FqgQHfuzg==",
       "cpu": [
         "arm"
       ],
@@ -2117,17 +2277,14 @@
         "linux"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.77.8.tgz",
-      "integrity": "sha512-6iIOIZtBFa2YfMsHqOb3qake3C9d/zlKxjooKKnTSo+6g6z+CLTzMXe1bOfayb7yxeenElmFoK1k54kWD/40+g==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.103.1.tgz",
+      "integrity": "sha512-rC+80/Xr9svo0ka2Zr/sjD+N1zEHTw2Urm/nsEjaVp5HSH2i22jwhTKTIqie2OLl6ti+qdYnbI0sSfxOYRtgrg==",
       "cpu": [
         "arm64"
       ],
@@ -2137,37 +2294,14 @@
         "linux"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-linux-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.77.8.tgz",
-      "integrity": "sha512-63GsFFHWN5yRLTWiSef32TM/XmjhCBx1DFhoqxmj+Yc6L9Z1h0lDHjjwdG6Sp5XTz5EmsaFKjpDgnQTP9hJX3Q==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-linux-musl-arm": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.77.8.tgz",
-      "integrity": "sha512-nFkhSl3uu9btubm+JBW7uRglNVJ8W8dGfzVqh3fyQJKS1oyBC3vT3VOtfbT9YivXk28wXscSHpqXZwY7bUuopA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.103.1.tgz",
+      "integrity": "sha512-N8L/kgVzXpnH+8d6ErIzqvb0l8kHODR3OfPaf0Azw6DOLGtEjwDRUbHno+G7iogGzyPOjKsM8OdyqHJj/bpTdw==",
       "cpu": [
         "arm"
       ],
@@ -2182,9 +2316,9 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.77.8.tgz",
-      "integrity": "sha512-j8cgQxNWecYK+aH8ESFsyam/Q6G+9gg8eJegiRVpA9x8yk3ykfHC7UdQWwUcF22ZcuY4zegrjJx8k+thsgsOVA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.103.1.tgz",
+      "integrity": "sha512-jMgG/C/VMo7+ShMFdk0xjJmQmYkj1PbJu/yrQiaQHpuo5pE2G+vnkEgsuM5EM3lTQ4MbMfnf715qy1fkbNPiUQ==",
       "cpu": [
         "arm64"
       ],
@@ -2198,12 +2332,12 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/sass-embedded-linux-musl-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.77.8.tgz",
-      "integrity": "sha512-oWveMe+8TFlP8WBWPna/+Ec5TV0CE+PxEutyi0ltSruBds2zxRq9dPVOqrpPcDN9QUx50vNZC0Afgch0aQEd0g==",
+    "node_modules/sass-embedded-linux-musl-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-riscv64/-/sass-embedded-linux-musl-riscv64-1.103.1.tgz",
+      "integrity": "sha512-LZm8rEvI6sKU87qPOlODsYeAs7CmWy0B4ShYkjG4OMcGCcV4Ffxn25XW4TFqmruThITQvJ8WT+WGblzdoxYgbA==",
       "cpu": [
-        "ia32"
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
@@ -2216,11 +2350,28 @@
       }
     },
     "node_modules/sass-embedded-linux-musl-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.77.8.tgz",
-      "integrity": "sha512-2NtRpMXHeFo9kaYxuZ+Ewwo39CE7BTS2JDfXkTjZTZqd8H+8KC53eBh516YQnn2oiqxSiKxm7a6pxbxGZGwXOQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-musl-x64/-/sass-embedded-linux-musl-x64-1.103.1.tgz",
+      "integrity": "sha512-rmKzgk4t6RpaDhSefbbnk5yrA4pk1nHlVhJECGay8yMfzK8eglATeY9fzPgt89xCuQk6rkOiy11e+m8tLYOW5Q==",
       "cpu": [
         "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-riscv64": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-riscv64/-/sass-embedded-linux-riscv64-1.103.1.tgz",
+      "integrity": "sha512-xydQmtxla31uMrmN6z+mAogVGdEMDmkUElVq2+udomX/TPZDYJBkApEyJl237M2VLWVv29v1N4U4i2Z4xa7SDA==",
+      "cpu": [
+        "riscv64"
       ],
       "license": "MIT",
       "optional": true,
@@ -2233,9 +2384,9 @@
       }
     },
     "node_modules/sass-embedded-linux-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.77.8.tgz",
-      "integrity": "sha512-ND5qZLWUCpOn7LJfOf0gLSZUWhNIysY+7NZK1Ctq+pM6tpJky3JM5I1jSMplNxv5H3o8p80n0gSm+fcjsEFfjQ==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.103.1.tgz",
+      "integrity": "sha512-Rln1oWm0MWKzzemOgQWrRFzfVBARwS9qxAidZPpCQHSohzPnWizFkmY1CUJad/YJNsA7sscueMdX63OEvxoM8w==",
       "cpu": [
         "x64"
       ],
@@ -2245,17 +2396,31 @@
         "linux"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/sass-embedded-unknown-all": {
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-unknown-all/-/sass-embedded-unknown-all-1.103.1.tgz",
+      "integrity": "sha512-p7kI4US8+n+YguKczXh+4KcodJnk+8cwv+QFdvMaz3OfPrdHV0EnhPsaVDWD9qXb1XXCEdUhpp6vQwGk3eKc3A==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "!android",
+        "!darwin",
+        "!linux",
+        "!win32"
+      ],
+      "peer": true,
+      "dependencies": {
+        "sass": "1.103.1"
+      }
+    },
     "node_modules/sass-embedded-win32-arm64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.77.8.tgz",
-      "integrity": "sha512-7L8zT6xzEvTYj86MvUWnbkWYCNQP+74HvruLILmiPPE+TCgOjgdi750709BtppVJGGZSs40ZuN6mi/YQyGtwXg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-arm64/-/sass-embedded-win32-arm64-1.103.1.tgz",
+      "integrity": "sha512-/0renOj3SpZGu4TA8CZJ6qZbTxGZk1khkPfiBTmV1uFB40ESYM5VsdXNj76P07bsAjIj9X2fCjTafLQFLSd9Nw==",
       "cpu": [
         "arm64"
       ],
@@ -2265,37 +2430,14 @@
         "win32"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/sass-embedded-win32-ia32": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.77.8.tgz",
-      "integrity": "sha512-7Buh+4bP0WyYn6XPbthkIa3M2vtcR8QIsFVg3JElVlr+8Ng19jqe0t0SwggDgbMX6AdQZC+Wj4F1BprZSok42A==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/sass-embedded-win32-x64": {
-      "version": "1.77.8",
-      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.77.8.tgz",
-      "integrity": "sha512-rZmLIx4/LLQm+4GW39sRJW0MIlDqmyV0fkRzTmhFP5i/wVC7cuj8TUubPHw18rv2rkHFfBZKZJTCkPjCS5Z+SA==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.103.1.tgz",
+      "integrity": "sha512-fIg60j9u5YlLUU3W8FvySMR4HHIo9R12HHFQTW7njyQ8nXqgR+t+XfCzGJloQka8g583BlAfu31Q76Ljr5o+9g==",
       "cpu": [
         "x64"
       ],
@@ -2305,9 +2447,6 @@
         "win32"
       ],
       "peer": true,
-      "bin": {
-        "sass": "dart-sass/sass.bat"
-      },
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2348,18 +2487,18 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.1.1.tgz",
-      "integrity": "sha512-rqEO6FZk8mv7Hyv4UCj3FD3b6Waqft605TLfsCe/BiaylRpyyMC0b+uA5TJKawX3KzMrdi3wsLbCaLplrQmBvQ==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/seroval-plugins": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.1.1.tgz",
-      "integrity": "sha512-qNSy1+nUj7hsCOon7AO4wdAIo9P0jrzAMp18XhiOzA6/uO5TKtP7ScozVJ8T293oRIvi5wyCHSM4TrJo/c/GJA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.6.tgz",
+      "integrity": "sha512-HXuLAX2pu/UByPpaeo/TaMfvMIi+1QqIoPJYCcAtU8QkVNwgR6MPlGuCQTErV1JwraaMbYaWVIBX7mppzGLATQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2388,20 +2527,20 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.8.21",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.8.21.tgz",
-      "integrity": "sha512-FHUGdoo7GVa1BTpGh/4UtwIISde0vSXoqNB6KFpHiTgkIY959tmCJ7NYQAWDfScBfnpoMGZR8lFz0DiwW/gFlw==",
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.15.tgz",
+      "integrity": "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.1.0",
-        "seroval": "^1.1.0",
-        "seroval-plugins": "^1.1.0"
+        "seroval": "~1.5.4",
+        "seroval-plugins": "~1.5.4"
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2412,18 +2551,6 @@
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==",
       "license": "CC0-1.0"
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -2437,38 +2564,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+    "node_modules/sync-child-process": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
+      "integrity": "sha512-8lD+t2KrrScJ/7KXCSyfhT3/hRq78rC0wBFqNJXv3mZyn6hW2ypM05JmlSvtqRbeq6jqA94oHbxAr2vYsJ8vDA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "is-number": "^7.0.0"
+        "sync-message-port": "^1.0.0"
       },
       "engines": {
-        "node": ">=8.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/sync-message-port": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sync-message-port/-/sync-message-port-1.2.0.tgz",
+      "integrity": "sha512-gAQ9qrUN/UCypHtGFbbe7Rc/f9bzO88IwrG8TDo/aMKAApKyD6E3W4Cm0EfhfBb6Z6SKt59tTCTfD+n1xmAvMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "peer": true
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2485,8 +2628,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
+    "dev": "NODE_ENV=development node build.js",
     "build": "node build.js",
-    "watch": "NODE_ENV=watch node build.js"
+    "watch": "NODE_ENV=watch node build.js",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
@@ -20,9 +22,9 @@
     "classnames": "^2.5.1",
     "csv-parse": "^5.5.6",
     "embla-carousel-solid": "^8.2.0",
-    "esbuild": "^0.23.1",
+    "esbuild": "^0.28.2",
     "esbuild-plugin-solid": "^0.6.0",
-    "esbuild-sass-plugin": "^3.3.1",
+    "esbuild-sass-plugin": "^3.7.0",
     "lodash.clonedeep": "^4.5.0",
     "postcss": "^8.4.41",
     "postcss-modules": "^6.0.0",
@@ -31,6 +33,7 @@
     "solid-js": "^1.8.21"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.9"
+    "@types/lodash.clonedeep": "^4.5.9",
+    "typescript": "^5.9.2"
   }
 }

--- a/src/components/CategoryRail/CategoryRail.tsx
+++ b/src/components/CategoryRail/CategoryRail.tsx
@@ -1,0 +1,80 @@
+import {createEffect, createSignal, onMount} from 'solid-js'
+import createEmblaCarousel from 'embla-carousel-solid'
+import cn from 'classnames'
+
+import type {CensusCategory} from '../Slide/slideData'
+import styles from './categoryRail.module.scss'
+
+interface CategoryRailProps {
+  categories: CensusCategory[]
+  selectedIndex: number
+  onSelect: (index: number) => void
+}
+
+export default function CategoryRail(props: CategoryRailProps) {
+  const [emblaRef, emblaApi] = createEmblaCarousel(() => ({
+    dragFree: true,
+    containScroll: 'trimSnaps',
+    align: 'center',
+  }))
+  const [canScrollPrev, setCanScrollPrev] = createSignal(false)
+  const [canScrollNext, setCanScrollNext] = createSignal(false)
+
+  const updateControls = () => {
+    setCanScrollPrev(emblaApi()?.canScrollPrev() ?? false)
+    setCanScrollNext(emblaApi()?.canScrollNext() ?? false)
+  }
+
+  onMount(() => {
+    const api = emblaApi()
+    if (!api) return
+
+    updateControls()
+    api.on('scroll', updateControls)
+    api.on('reInit', updateControls)
+  })
+
+  createEffect(() => {
+    const index = props.selectedIndex
+    emblaApi()?.scrollTo(index)
+  })
+
+  return (
+    <nav class={styles.rail} aria-label="Census categories">
+      <button
+        class={styles.railArrow}
+        type="button"
+        aria-label="Scroll categories left"
+        disabled={!canScrollPrev()}
+        onclick={() => emblaApi()?.scrollPrev()}
+      >
+        ‹
+      </button>
+
+      <div class={styles.viewport} ref={emblaRef}>
+        <div class={styles.track}>
+          {props.categories.map((category, index) => (
+            <button
+              class={cn(styles.item, props.selectedIndex === index && styles.selected)}
+              type="button"
+              aria-current={props.selectedIndex === index ? 'page' : undefined}
+              onclick={() => props.onSelect(index)}
+            >
+              {category.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <button
+        class={styles.railArrow}
+        type="button"
+        aria-label="Scroll categories right"
+        disabled={!canScrollNext()}
+        onclick={() => emblaApi()?.scrollNext()}
+      >
+        ›
+      </button>
+    </nav>
+  )
+}

--- a/src/components/CategoryRail/categoryRail.module.scss
+++ b/src/components/CategoryRail/categoryRail.module.scss
@@ -1,0 +1,109 @@
+.rail {
+  min-height: 4.15rem;
+  padding: .45rem .65rem;
+  box-sizing: border-box;
+  border-top: 1px solid rgba(255, 255, 255, .08);
+  background: rgba(17, 17, 17, .97);
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr) 2.5rem;
+  align-items: center;
+  gap: .4rem;
+  z-index: 10;
+}
+
+.viewport {
+  overflow: hidden;
+  min-width: 0;
+}
+
+.track {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+  touch-action: pan-y pinch-zoom;
+}
+
+.item,
+.railArrow {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: #8d8d8d;
+  font-family: 'Archivo', sans-serif;
+  cursor: pointer;
+}
+
+.item {
+  flex: 0 0 auto;
+  position: relative;
+  padding: .7rem .7rem .8rem;
+  font-size: .78rem;
+  white-space: nowrap;
+  transition: color .16s ease, transform .16s ease;
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: .7rem;
+    right: .7rem;
+    bottom: .3rem;
+    height: 2px;
+    background: #ff1f50;
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform .16s ease;
+  }
+
+  &:hover {
+    color: #ddd;
+  }
+
+  &.selected {
+    color: #fff;
+    transform: translateY(-1px);
+
+    &::after {
+      transform: scaleX(1);
+    }
+  }
+}
+
+.railArrow {
+  height: 2.5rem;
+  font-family: Georgia, serif;
+  font-size: 1.9rem;
+  line-height: 1;
+  transition: color .16s ease, opacity .16s ease;
+
+  &:hover:not(:disabled) {
+    color: #fff;
+  }
+
+  &:disabled {
+    opacity: .18;
+    cursor: default;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .rail {
+    min-height: 3.75rem;
+    padding: .35rem .3rem;
+    grid-template-columns: 2rem minmax(0, 1fr) 2rem;
+  }
+
+  .item {
+    padding-left: .55rem;
+    padding-right: .55rem;
+    font-size: .72rem;
+
+    &::after {
+      left: .55rem;
+      right: .55rem;
+    }
+  }
+
+  .railArrow {
+    font-size: 1.6rem;
+  }
+}

--- a/src/components/ExplorerHeader/ExplorerHeader.tsx
+++ b/src/components/ExplorerHeader/ExplorerHeader.tsx
@@ -1,0 +1,161 @@
+import {createSignal, onCleanup, onMount, Show} from 'solid-js'
+
+import type {CensusCategory} from '../Slide/slideData'
+import titleLogo from '../../images/title.svg'
+
+import styles from './explorerHeader.module.scss'
+
+interface ExplorerHeaderProps {
+  categories: CensusCategory[]
+  selectedIndex: number
+  onSelect: (index: number) => void
+}
+
+export default function ExplorerHeader(props: ExplorerHeaderProps) {
+  const [categoryOpen, setCategoryOpen] = createSignal(false)
+
+  let categoryDropdown: HTMLDivElement | undefined
+
+  const selectedCategory = () =>
+    props.categories[props.selectedIndex] ?? props.categories[0]
+
+  const selectCategory = (index: number) => {
+    props.onSelect(index)
+    setCategoryOpen(false)
+  }
+
+  const handleTriggerKeyDown = (event: KeyboardEvent) => {
+    if (
+      event.key === 'Enter' ||
+      event.key === ' ' ||
+      event.key === 'ArrowDown'
+    ) {
+      event.preventDefault()
+      setCategoryOpen(true)
+    }
+
+    if (event.key === 'Escape') {
+      setCategoryOpen(false)
+    }
+  }
+
+  onMount(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!(event.target instanceof Node)) return
+
+      if (
+        categoryDropdown &&
+        !categoryDropdown.contains(event.target)
+      ) {
+        setCategoryOpen(false)
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setCategoryOpen(false)
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown)
+    window.addEventListener('keydown', handleKeyDown)
+
+    onCleanup(() => {
+      window.removeEventListener('pointerdown', handlePointerDown)
+      window.removeEventListener('keydown', handleKeyDown)
+    })
+  })
+
+  return (
+    <header class={styles.header}>
+      <button
+        class={styles.brand}
+        type="button"
+        aria-label="Go to census cover"
+        onclick={() => props.onSelect(0)}
+      >
+        <img
+          src={titleLogo}
+          alt="The HasanAbi Census"
+        />
+      </button>
+
+      <div class={styles.controls}>
+        <div
+          class={styles.categoryControl}
+          ref={categoryDropdown}
+        >
+          <button
+            class={styles.categoryTrigger}
+            type="button"
+            aria-label={`Census category: ${selectedCategory()?.name}`}
+            aria-haspopup="menu"
+            aria-expanded={categoryOpen()}
+            onclick={() => setCategoryOpen(!categoryOpen())}
+            onkeydown={handleTriggerKeyDown}
+          >
+            <span class={styles.categoryLabel}>
+              Category
+            </span>
+
+            <span class={styles.categoryValue}>
+              {selectedCategory()?.name}
+            </span>
+
+            <span
+              class={styles.categoryCaret}
+              classList={{
+                [styles.categoryCaretOpen]: categoryOpen(),
+              }}
+              aria-hidden="true"
+            />
+          </button>
+
+          <Show when={categoryOpen()}>
+            <div
+              class={styles.categoryMenu}
+              role="menu"
+              aria-label="Census categories"
+            >
+              {props.categories.map((category, index) => (
+                <button
+                  class={styles.categoryOption}
+                  classList={{
+                    [styles.categoryOptionSelected]:
+                      props.selectedIndex === index,
+                  }}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={props.selectedIndex === index}
+                  onclick={() => selectCategory(index)}
+                >
+                  <span>{category.name}</span>
+
+                  <Show when={props.selectedIndex === index}>
+                    <span
+                      class={styles.selectedMark}
+                      aria-hidden="true"
+                    />
+                  </Show>
+                </button>
+              ))}
+            </div>
+          </Show>
+        </div>
+
+        <div
+          class={styles.view}
+          aria-label="Current data view"
+        >
+          <span class={styles.viewLabel}>
+            View
+          </span>
+
+          <span class={styles.viewValue}>
+            Snapshot
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/ExplorerHeader/explorerHeader.module.scss
+++ b/src/components/ExplorerHeader/explorerHeader.module.scss
@@ -1,0 +1,308 @@
+.header {
+  min-height: 4.4rem;
+  padding: .7rem 1.25rem;
+  box-sizing: border-box;
+
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+
+  background: rgba(17, 17, 17, .94);
+  backdrop-filter: blur(12px);
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  position: relative;
+  z-index: 20;
+}
+
+.brand {
+  width: min(23rem, 42vw);
+  padding: 0;
+
+  border: 0;
+  background: transparent;
+
+  cursor: pointer;
+  line-height: 0;
+
+  img {
+    display: block;
+
+    width: 100%;
+    height: auto;
+    max-height: 2.45rem;
+
+    object-fit: contain;
+    object-position: left center;
+  }
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: .7rem;
+
+  font-family: 'Archivo', sans-serif;
+}
+
+.categoryControl,
+.view {
+  height: 2.7rem;
+
+  border: 1px solid rgba(255, 255, 255, .13);
+
+  background: #171717;
+}
+
+.categoryControl {
+  position: relative;
+
+  display: flex;
+  align-items: stretch;
+}
+
+.categoryTrigger {
+  min-width: 13rem;
+  height: 100%;
+
+  padding: 0 .8rem;
+
+  border: 0;
+  outline: 0;
+
+  background: transparent;
+  color: #eee;
+
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+
+  font: inherit;
+
+  cursor: pointer;
+
+  transition:
+    background .15s ease,
+    border-color .15s ease;
+
+  &:hover {
+    background: #1e1e1e;
+  }
+
+  &:focus-visible {
+    outline: 1px solid rgba(255, 31, 80, .8);
+    outline-offset: -1px;
+  }
+}
+
+.categoryLabel,
+.viewLabel {
+  color: #777;
+
+  font-size: .62rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.categoryValue {
+  min-width: 0;
+
+  margin-left: auto;
+
+  color: #eee;
+
+  font-size: .78rem;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.categoryCaret {
+  width: 0;
+  height: 0;
+
+  margin-left: .2rem;
+
+  border-left: .23rem solid transparent;
+  border-right: .23rem solid transparent;
+  border-top: .3rem solid #888;
+
+  transition:
+    transform .18s ease,
+    border-color .18s ease;
+}
+
+.categoryCaretOpen {
+  transform: rotate(180deg);
+  border-top-color: #ff1f50;
+}
+
+.categoryMenu {
+  position: absolute;
+
+  top: calc(100% + .4rem);
+  right: 0;
+
+  min-width: 100%;
+  width: max-content;
+  max-width: min(20rem, calc(100vw - 2rem));
+  max-height: min(65vh, 25rem);
+
+  padding: .3rem;
+  box-sizing: border-box;
+
+  overflow-y: auto;
+  overscroll-behavior: contain;
+
+  border: 1px solid rgba(255, 255, 255, .13);
+
+  background: rgba(23, 23, 23, .98);
+
+  box-shadow:
+    0 .5rem 1.6rem rgba(0, 0, 0, .42),
+    0 1px 0 rgba(255, 255, 255, .03) inset;
+
+  backdrop-filter: blur(16px);
+
+  z-index: 100;
+
+  transform-origin: top right;
+
+  animation: category-menu-in .14s ease-out;
+}
+
+.categoryOption {
+  position: relative;
+
+  width: 100%;
+
+  padding: .58rem .75rem;
+
+  border: 0;
+
+  background: transparent;
+  color: #aaa;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  font: inherit;
+  font-size: .72rem;
+
+  text-align: left;
+  white-space: nowrap;
+
+  cursor: pointer;
+
+  transition:
+    background .12s ease,
+    color .12s ease;
+
+  &:hover,
+  &:focus-visible {
+    outline: 0;
+
+    background: #242424;
+    color: #fff;
+  }
+}
+
+.categoryOptionSelected {
+  background: rgba(255, 31, 80, .08);
+  color: #fff;
+
+  &::before {
+    content: '';
+
+    position: absolute;
+
+    top: .35rem;
+    bottom: .35rem;
+    left: 0;
+
+    width: 2px;
+
+    background: #ff1f50;
+  }
+}
+
+.selectedMark {
+  width: .35rem;
+  height: .35rem;
+
+  flex: 0 0 auto;
+
+  border-radius: 50%;
+
+  background: #ff1f50;
+
+  box-shadow: 0 0 .55rem rgba(255, 31, 80, .45);
+}
+
+.view {
+  padding: 0 .85rem;
+
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+}
+
+.viewValue {
+  color: #eee;
+
+  font-size: .78rem;
+}
+
+@keyframes category-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(-.3rem) scale(.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media screen and (max-width: 760px) {
+  .header {
+    min-height: 4rem;
+
+    padding: .6rem .8rem;
+  }
+
+  .brand {
+    width: min(12rem, 42vw);
+  }
+
+  .categoryTrigger {
+    min-width: 8rem;
+
+    padding: 0 .65rem;
+  }
+
+  .categoryLabel {
+    display: none;
+  }
+
+  .categoryValue {
+    margin-left: 0;
+  }
+
+  .categoryMenu {
+    right: 0;
+
+    max-width: calc(100vw - 1.6rem);
+  }
+
+  .view {
+    display: none;
+  }
+}

--- a/src/components/ProjectFooter/ProjectFooter.tsx
+++ b/src/components/ProjectFooter/ProjectFooter.tsx
@@ -1,0 +1,17 @@
+import styles from './projectFooter.module.scss'
+
+export default function ProjectFooter() {
+  return (
+    <footer class={styles.footer}>
+      <span>Original project by</span>
+
+      <a
+        href="https://github.com/brilliantdrink"
+        target="_blank"
+        rel="noreferrer"
+      >
+        @brilliantdrink
+      </a>
+    </footer>
+  )
+}

--- a/src/components/ProjectFooter/projectFooter.module.scss
+++ b/src/components/ProjectFooter/projectFooter.module.scss
@@ -1,0 +1,40 @@
+.footer {
+  min-height: 2rem;
+  padding: .4rem 1rem .5rem;
+  box-sizing: border-box;
+
+  border-top: 1px solid rgba(255, 255, 255, .045);
+
+  background: #0d0d0d;
+  color: #666;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .3rem;
+
+  font-family: 'Archivo', sans-serif;
+  font-size: .58rem;
+  letter-spacing: .025em;
+
+  a {
+    color: #999;
+    text-decoration: none;
+
+    transition: color .15s ease;
+
+    &:hover,
+    &:focus-visible {
+      color: #ff1f50;
+    }
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .footer {
+    min-height: 1.8rem;
+    padding: .3rem .75rem .4rem;
+
+    font-size: .54rem;
+  }
+}

--- a/src/components/Slide/BarChartSlide.tsx
+++ b/src/components/Slide/BarChartSlide.tsx
@@ -1,47 +1,168 @@
-import {createMemo, createSignal, JSX, onMount, Show} from 'solid-js'
+import {
+  createMemo,
+  createSignal,
+  JSX,
+  onCleanup,
+  onMount,
+  Show,
+} from 'solid-js'
 import {Bar} from 'solid-chartjs'
-import {Chart, ChartData, Colors, Legend, LinearScale, Title, Tooltip} from 'chart.js'
+import {
+  Chart,
+  ChartData,
+  Colors,
+  Legend,
+  LinearScale,
+  Title,
+  Tooltip,
+} from 'chart.js'
 import DataLabels from 'chartjs-plugin-datalabels'
 import {createMediaQuery} from '@solid-primitives/media'
-import {createWindowSize} from '@solid-primitives/resize-observer'
 
 import styles from './slide.module.scss'
-import {plugins, stackedBarChart} from './options'
+import {
+  plugins,
+  stackedBarChart,
+} from './options'
 import getStackedBarData from './getStackedBarData'
 
 interface BarChartSlideProps {
-  dataFile: string,
-  title: string,
+  dataFile: string
+  title: string
   note?: string | JSX.Element
   colors?: string[]
 }
 
-export default function BarChartSlide(props: BarChartSlideProps) {
-  const [data, setData] = createSignal<ChartData>(null!)
-  const size = createWindowSize()
-  const isMedium = createMediaQuery("(max-width: 1200px)")
-  const isSmall = createMediaQuery("(max-width: 700px)")
-  const isTiny = createMediaQuery("(max-width: 600px)")
+interface FrameSize {
+  width: number
+  height: number
+}
+
+export default function BarChartSlide(
+  props: BarChartSlideProps,
+) {
+  const [data, setData] =
+    createSignal<ChartData>(null!)
+
+  const [frameSize, setFrameSize] =
+    createSignal<FrameSize>({
+      width: 1,
+      height: 1,
+    })
+
+  const isMedium = createMediaQuery(
+    '(max-width: 1200px)',
+  )
+
+  const isSmall = createMediaQuery(
+    '(max-width: 700px)',
+  )
+
+  const isTiny = createMediaQuery(
+    '(max-width: 600px)',
+  )
+
+  let chartFrame:
+    | HTMLDivElement
+    | undefined
+
   const canvasWidth = createMemo(() => {
-    if (isSmall()) return size.width - 36
-    else if (isMedium()) return size.width * .8
-    else return size.width * .6
+    const width = frameSize().width
+
+    if (isSmall()) {
+      return Math.max(
+        1,
+        width - 36,
+      )
+    }
+
+    if (isMedium()) {
+      return Math.max(
+        1,
+        width * .8,
+      )
+    }
+
+    return Math.max(
+      1,
+      width * .6,
+    )
   })
-  const canvasHeight = createMemo(() => {
-    return size.height * .8 - 22 * 2
-  })
+
+  const canvasHeight = createMemo(() =>
+    Math.max(
+      1,
+      frameSize().height,
+    ),
+  )
 
   onMount(() => {
-    Chart.register(Title, Tooltip, Legend, Colors, DataLabels, LinearScale)
-    getStackedBarData(props.dataFile, props.title, props.colors).then(setData)
+    Chart.register(
+      Title,
+      Tooltip,
+      Legend,
+      Colors,
+      DataLabels,
+      LinearScale,
+    )
+
+    getStackedBarData(
+      props.dataFile,
+      props.title,
+      props.colors,
+    ).then(setData)
+
+    if (!chartFrame) return
+
+    const resizeObserver =
+      new ResizeObserver((entries) => {
+        const entry = entries[0]
+
+        if (!entry) return
+
+        setFrameSize({
+          width:
+            entry.contentRect.width,
+          height:
+            entry.contentRect.height,
+        })
+      })
+
+    resizeObserver.observe(
+      chartFrame,
+    )
+
+    onCleanup(() => {
+      resizeObserver.disconnect()
+    })
   })
 
-  return <>
+  return (
     <div class={styles.slide}>
-      <h2>{props.title}</h2>
-      <Show when={props.note}><p>{props.note}</p></Show>
-      <Bar class={styles.chart} data={data()} options={stackedBarChart(props.title, isTiny())} plugins={plugins}
-        height={canvasHeight()} width={canvasWidth()} />
+      <div class={styles.slideHeader}>
+        <h2>{props.title}</h2>
+
+        <Show when={props.note}>
+          <p>{props.note}</p>
+        </Show>
+      </div>
+
+      <div
+        class={styles.chartFrame}
+        ref={chartFrame}
+      >
+        <Bar
+          class={styles.chart}
+          data={data()}
+          options={stackedBarChart(
+            props.title,
+            isTiny(),
+          )}
+          plugins={plugins}
+          height={canvasHeight()}
+          width={canvasWidth()}
+        />
+      </div>
     </div>
-  </>
+  )
 }

--- a/src/components/Slide/slide.module.scss
+++ b/src/components/Slide/slide.module.scss
@@ -1,13 +1,16 @@
 .slide {
   justify-self: start;
+
   height: 100%;
-  padding-bottom: 118px;
+  width: 100%;
+
+  padding: 1rem 0;
   box-sizing: border-box;
 
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
+
+  min-height: 0;
 
   font-size: 18px;
 
@@ -15,72 +18,165 @@
     margin: 0;
   }
 
-  &.home > * {
-    margin: .5rem 0;
+  &.home {
+    justify-content: center;
+    align-items: center;
+
+    > * {
+      margin: .5rem 0;
+    }
   }
 
-  h1, h2, h3 {
-    font-family: 'Archivo', sans-serif;
+  h1,
+  h2,
+  h3 {
+    font-family:
+      'Archivo',
+      sans-serif;
   }
 
   h1 {
     position: relative;
+
     margin-top: 2rem;
+
     font-size: 5rem;
+
     color: transparent;
 
-    background: url('../../images/title.svg') center / contain no-repeat;
+    background:
+      url('../../images/title.svg')
+      center / contain
+      no-repeat;
   }
 
-  @media screen and (max-width: 1600px) {
+  @media screen and
+    (max-width: 1600px) {
     h1 {
-      font-size: min(5rem, calc(12vw));
+      font-size:
+        min(
+          5rem,
+          calc(12vw)
+        );
 
       word-wrap: normal;
       text-align: center;
-      background-image: url('../../images/title_stacked.svg');
+
+      background-image:
+        url(
+          '../../images/title_stacked.svg'
+        );
     }
   }
 
   .comment {
     position: absolute;
+
     right: -2rem;
     top: -1rem;
+
     font-size: 1.5rem;
+
     $rotate: rotate(12deg);
+
     transform-origin: center;
-    animation: pulse .5s alternate infinite cubic-bezier(.4, 0, .6, 1);
-    background: url('../../images/numbers-guy.svg') center / contain no-repeat;
+
+    animation:
+      pulse
+      .5s
+      alternate
+      infinite
+      cubic-bezier(
+        .4,
+        0,
+        .6,
+        1
+      );
+
+    background:
+      url(
+        '../../images/numbers-guy.svg'
+      )
+      center / contain
+      no-repeat;
 
     @keyframes pulse {
       from {
-        transform: $rotate scale(.95);
+        transform:
+          $rotate
+          scale(.95);
       }
+
       to {
-        transform: $rotate scale(1.05);
+        transform:
+          $rotate
+          scale(1.05);
       }
     }
   }
 
   .signature {
     width: 4rem;
+
     margin-top: 2rem;
+
     opacity: .2;
 
     font-size: .8rem;
     text-align: right;
+
     color: white;
   }
 
   .inlineIcon {
     height: 1.4em;
+
     vertical-align: middle;
 
     position: relative;
+
     bottom: .2em;
   }
+}
 
-  canvas {
-    margin-top: 1rem;
+.slideHeader {
+  flex: 0 0 auto;
+
+  width: 100%;
+
+  padding: 0 1rem .65rem;
+  box-sizing: border-box;
+
+  text-align: center;
+
+  h2 {
+    margin: 0;
+
+    font-size: 1.8rem;
   }
+
+  p {
+    margin:
+      .25rem
+      0
+      0;
+  }
+}
+
+.chartFrame {
+  flex: 1 1 auto;
+
+  width: 100%;
+
+  min-height: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  overflow: hidden;
+}
+
+.chart {
+  display: block;
 }

--- a/src/components/Slide/slideData.tsx
+++ b/src/components/Slide/slideData.tsx
@@ -1,99 +1,191 @@
 import {JSX} from 'solid-js'
 
-import ageFile from "../../data/age.csv"
-import genderFile from "../../data/gender.csv"
-import politicsFile from "../../data/politics.csv"
-import ethnicityFile from "../../data/ethnicity.csv"
-import religionFile from "../../data/religion.csv"
-import sexualityFile from "../../data/sexuality.csv"
-import heightFile from "../../data/height.csv"
-import transFile from "../../data/trans.csv"
-import locationFile from "../../data/location.csv"
-import salaryFile from "../../data/salary.csv"
-import educationFile from "../../data/education.csv"
-import sexHaversFile from "../../data/sex-havers.csv"
-import weebFile from "../../data/weeb.csv"
-import eatingFile from "../../data/eating.csv"
-import neurodivergenceFile from "../../data/neurodivergence.csv"
-import gamingFile from "../../data/gaming.csv"
-import watchedFile from "../../data/watched.csv"
-import activismFile from "../../data/activism.csv"
-import housingFile from "../../data/housing.csv"
-import discoveryFile from "../../data/discovery.csv"
+import ageFile from '../../data/age.csv'
+import genderFile from '../../data/gender.csv'
+import politicsFile from '../../data/politics.csv'
+import ethnicityFile from '../../data/ethnicity.csv'
+import religionFile from '../../data/religion.csv'
+import sexualityFile from '../../data/sexuality.csv'
+import heightFile from '../../data/height.csv'
+import transFile from '../../data/trans.csv'
+import locationFile from '../../data/location.csv'
+import salaryFile from '../../data/salary.csv'
+import educationFile from '../../data/education.csv'
+import sexHaversFile from '../../data/sex-havers.csv'
+import weebFile from '../../data/weeb.csv'
+import eatingFile from '../../data/eating.csv'
+import neurodivergenceFile from '../../data/neurodivergence.csv'
+import gamingFile from '../../data/gaming.csv'
+import watchedFile from '../../data/watched.csv'
+import activismFile from '../../data/activism.csv'
+import housingFile from '../../data/housing.csv'
+import discoveryFile from '../../data/discovery.csv'
 
 import styles from './slide.module.scss'
 import {colorsAge, colorsHeight} from './colors'
 
-const madge = 'https://cdn.betterttv.net/emote/6083d2f139b5010444d0540e/3x.webp'
+const madge =
+  'https://cdn.betterttv.net/emote/6083d2f139b5010444d0540e/3x.webp'
 
-interface SlideData {
-  name: string,
+export type CensusCategoryId =
+  | 'home'
+  | 'age'
+  | 'gender'
+  | 'political-ideology'
+  | 'ethnicity'
+  | 'religion'
+  | 'sexuality'
+  | 'height'
+  | 'trans-chatters'
+  | 'location'
+  | 'salary'
+  | 'education'
+  | 'vcard'
+  | 'weebs'
+  | 'diet'
+  | 'neurodiversity'
+  | 'gayming-frogs'
+  | 'years-watched'
+  | 'political-activism'
+  | 'housing'
+  | 'discovery'
+
+export interface CensusCategory {
+  id: CensusCategoryId
+  name: string
+}
+
+export interface SlideData extends CensusCategory {
   fileUrl: string
   note?: string | JSX.Element
   colors?: string[]
 }
 
-export const barChartSlides: SlideData[] = [{
-  name: 'Age',
-  fileUrl: ageFile,
-  colors: colorsAge,
-}, {
-  name: 'Gender',
-  fileUrl: genderFile,
-}, {
-  name: 'Political Ideology',
-  fileUrl: politicsFile,
-}, {
-  name: 'Ethnicity',
-  fileUrl: ethnicityFile,
-}, {
-  name: 'Religion',
-  fileUrl: religionFile,
-}, {
-  name: 'Sexuality',
-  fileUrl: sexualityFile,
-}, {
-  name: 'Height',
-  fileUrl: heightFile,
-  note: <>(Categories changed for 2023 <img src={madge} class={styles.inlineIcon} alt={''} /> )</>,
-  colors: colorsHeight,
-}, {
-  name: 'Trans Chatters',
-  fileUrl: transFile,
-}, {
-  name: 'Location',
-  fileUrl: locationFile,
-}, {
-  name: 'Salary',
-  fileUrl: salaryFile,
-}, {
-  name: 'Education',
-  fileUrl: educationFile,
-}, {
-  name: 'VCARD',
-  fileUrl: sexHaversFile,
-}, {
-  name: 'Weebs',
-  fileUrl: weebFile,
-}, {
-  name: 'Diet',
-  fileUrl: eatingFile,
-}, {
-  name: 'Neurodiversity',
-  fileUrl: neurodivergenceFile,
-}, {
-  name: 'Gayming Frogs',
-  fileUrl: gamingFile,
-}, {
-  name: 'Years Watched',
-  fileUrl: watchedFile,
-}, {
-  name: 'Political Activism',
-  fileUrl: activismFile,
-}, {
-  name: 'Housing',
-  fileUrl: housingFile,
-}, {
-  name: 'Discovery',
-  fileUrl: discoveryFile,
-}]
+export const homeCategory: CensusCategory = {
+  id: 'home',
+  name: 'Home',
+}
+
+export const barChartSlides: SlideData[] = [
+  {
+    id: 'age',
+    name: 'Age',
+    fileUrl: ageFile,
+    colors: colorsAge,
+  },
+  {
+    id: 'gender',
+    name: 'Gender',
+    fileUrl: genderFile,
+  },
+  {
+    id: 'political-ideology',
+    name: 'Political Ideology',
+    fileUrl: politicsFile,
+  },
+  {
+    id: 'ethnicity',
+    name: 'Ethnicity',
+    fileUrl: ethnicityFile,
+  },
+  {
+    id: 'religion',
+    name: 'Religion',
+    fileUrl: religionFile,
+  },
+  {
+    id: 'sexuality',
+    name: 'Sexuality',
+    fileUrl: sexualityFile,
+  },
+  {
+    id: 'height',
+    name: 'Height',
+    fileUrl: heightFile,
+    note: (
+      <>
+        (Categories changed for 2023{' '}
+        <img
+          src={madge}
+          class={styles.inlineIcon}
+          alt=""
+        />{' '}
+        )
+      </>
+    ),
+    colors: colorsHeight,
+  },
+  {
+    id: 'trans-chatters',
+    name: 'Trans Chatters',
+    fileUrl: transFile,
+  },
+  {
+    id: 'location',
+    name: 'Location',
+    fileUrl: locationFile,
+  },
+  {
+    id: 'salary',
+    name: 'Salary',
+    fileUrl: salaryFile,
+  },
+  {
+    id: 'education',
+    name: 'Education',
+    fileUrl: educationFile,
+  },
+  {
+    id: 'vcard',
+    name: 'VCARD',
+    fileUrl: sexHaversFile,
+  },
+  {
+    id: 'weebs',
+    name: 'Weebs',
+    fileUrl: weebFile,
+  },
+  {
+    id: 'diet',
+    name: 'Diet',
+    fileUrl: eatingFile,
+  },
+  {
+    id: 'neurodiversity',
+    name: 'Neurodiversity',
+    fileUrl: neurodivergenceFile,
+  },
+  {
+    id: 'gayming-frogs',
+    name: 'Gayming Frogs',
+    fileUrl: gamingFile,
+  },
+  {
+    id: 'years-watched',
+    name: 'Years Watched',
+    fileUrl: watchedFile,
+  },
+  {
+    id: 'political-activism',
+    name: 'Political Activism',
+    fileUrl: activismFile,
+  },
+  {
+    id: 'housing',
+    name: 'Housing',
+    fileUrl: housingFile,
+  },
+  {
+    id: 'discovery',
+    name: 'Discovery',
+    fileUrl: discoveryFile,
+  },
+]
+
+export const censusCategories: CensusCategory[] = [
+  homeCategory,
+  ...barChartSlides.map(({id, name}) => ({
+    id,
+    name,
+  })),
+]

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,153 +1,195 @@
-import {createEffect, createSignal, onMount, Show} from 'solid-js'
+import {createSignal, onCleanup, onMount} from 'solid-js'
 import createEmblaCarousel from 'embla-carousel-solid'
-import {default as cn} from 'classnames'
-import {BsBoxArrowInLeft, BsBoxArrowInRight} from 'solid-icons/bs'
-import {FaSolidCaretDown} from 'solid-icons/fa'
-import {createMediaQuery} from '@solid-primitives/media'
+import cn from 'classnames'
+import {
+  BsBoxArrowInLeft,
+  BsBoxArrowInRight,
+} from 'solid-icons/bs'
+
 import {HomeSlide} from '../Slide'
+import BarChartSlide from '../Slide/BarChartSlide'
+import {
+  barChartSlides,
+  censusCategories,
+} from '../Slide/slideData'
+import ExplorerHeader from '../ExplorerHeader/ExplorerHeader'
+import CategoryRail from '../CategoryRail/CategoryRail'
+import ProjectFooter from '../ProjectFooter/ProjectFooter'
 
 import styles from './slider.module.scss'
 
-import BarChartSlide from '../Slide/BarChartSlide'
-import {barChartSlides} from '../Slide/slideData'
-
 export default function Slider() {
   const [emblaRef, emblaApi] = createEmblaCarousel()
-  const [canScrollNext, setCanScrollNext] = createSignal(false)
-  const [canScrollPrev, setCanScrollPrev] = createSignal(false)
-  const [slideIndex, setSlideIndex] = createSignal(0)
 
-  function resetCanScroll() {
-    setCanScrollNext(emblaApi()?.canScrollNext() ?? false)
-    setCanScrollPrev(emblaApi()?.canScrollPrev() ?? false)
-    setSlideIndex(emblaApi()?.selectedScrollSnap() ?? 0)
+  const [canScrollNext, setCanScrollNext] =
+    createSignal(false)
+
+  const [canScrollPrev, setCanScrollPrev] =
+    createSignal(false)
+
+  const [slideIndex, setSlideIndex] =
+    createSignal(0)
+
+  const syncCarouselState = () => {
+    const api = emblaApi()
+
+    if (!api) return
+
+    setCanScrollNext(api.canScrollNext())
+    setCanScrollPrev(api.canScrollPrev())
+    setSlideIndex(api.selectedScrollSnap())
+  }
+
+  const selectSlide = (index: number) => {
+    emblaApi()?.scrollTo(index)
   }
 
   onMount(() => {
     const api = emblaApi()
-    if (api) {
-      window.addEventListener('keydown', (e) => {
-        if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) return
-        if (e.key === 'ArrowRight') api.scrollNext()
-        if (e.key === 'ArrowLeft') api.scrollPrev()
-      })
-      resetCanScroll()
-      api.on('select', resetCanScroll)
-      api.on('select', () => {
-        navEmblaApi()?.scrollTo(emblaApi()?.selectedScrollSnap() ?? 0)
-      })
-    }
-    const isolateArrowButtonEvent = (e: Event) => {
-      if (!(e.target instanceof Element)) return
-      if (!e.target.closest('button')?.classList.contains(styles.arrow)) return
-      e.preventDefault()
-      e.stopPropagation()
-    }
-    window.addEventListener('mousedown', isolateArrowButtonEvent)
-    window.addEventListener('pointerdown', isolateArrowButtonEvent)
-    window.addEventListener('touchstart', isolateArrowButtonEvent)
-  })
 
+    if (!api) return
 
-  const isSmall = createMediaQuery("(max-width: 900px)")
-  const [navExpanded, setNavExpanded] = createSignal(false)
-  const [navEmblaRef, navEmblaApi] = createEmblaCarousel(() => ({
-    dragFree: true,
-    containScroll: false,
-    axis: 'y',
-    watchSlides: false,
-  }))
-  const [navIndex, setNavIndex] = createSignal(0)
-
-  onMount(() => {
-    const api = navEmblaApi()
-    if (api) {
-      const itemHeight = 3 * 16
-      api.on('pointerUp', () => {
-        const {scrollTo, target, location} = api.internalEngine()
-        const diffToTarget = target.get() - location.get()
-        const factor = Math.abs(diffToTarget) < itemHeight / 2.5 ? 10 : 0.1
-        const distance = diffToTarget * factor
-        scrollTo.distance(distance, true)
-      })
-      const updateStyles = () => {
-        const itemAmount = api.scrollSnapList().length
-        const items = api.slideNodes()
-        const maxDistance = 2.5
-        api.scrollSnapList().map((snapPosition, i) => {
-          const distance = Math.abs(snapPosition - api.scrollProgress())
-          const absoluteDistance = distance * (itemAmount - 1)
-          const proximity = (absoluteDistance / maxDistance) * -1 + 1
-          items[i].style.opacity = String(proximity)
-          items[i].style.setProperty('--scale', String(1 - (absoluteDistance / maxDistance) * .1))
-        })
+    const handleKeyDown = (
+      event: KeyboardEvent,
+    ) => {
+      if (
+        event.metaKey ||
+        event.altKey ||
+        event.ctrlKey ||
+        event.shiftKey
+      ) {
+        return
       }
-      api.on('scroll', updateStyles)
-      updateStyles()
-      api.on('select', () => {
-        emblaApi()?.scrollTo(api.selectedScrollSnap())
-        setNavIndex(api.selectedScrollSnap())
-      })
 
-      window.addEventListener('pointerdown', (e) => {
-        if (!e.target || !(e.target instanceof Element)) return
-        if (!e.target.classList.contains(styles.item)) {
-          setNavExpanded(false)
-        }
-      })
+      if (
+        event.target instanceof
+          HTMLInputElement ||
+        event.target instanceof
+          HTMLSelectElement ||
+        event.target instanceof
+          HTMLButtonElement
+      ) {
+        return
+      }
+
+      if (event.key === 'ArrowRight') {
+        api.scrollNext()
+      }
+
+      if (event.key === 'ArrowLeft') {
+        api.scrollPrev()
+      }
     }
+
+    syncCarouselState()
+
+    api.on('select', syncCarouselState)
+    api.on('reInit', syncCarouselState)
+
+    window.addEventListener(
+      'keydown',
+      handleKeyDown,
+    )
+
+    onCleanup(() => {
+      window.removeEventListener(
+        'keydown',
+        handleKeyDown,
+      )
+
+      api.off(
+        'select',
+        syncCarouselState,
+      )
+
+      api.off(
+        'reInit',
+        syncCarouselState,
+      )
+    })
   })
 
-  const allSlides = [{name: 'Cover'}, ...barChartSlides]
+  return (
+    <main class={styles.explorer}>
+      <ExplorerHeader
+        categories={censusCategories}
+        selectedIndex={slideIndex()}
+        onSelect={selectSlide}
+      />
 
-  return <>
-    <div class={styles.slider} ref={emblaRef}>
-      <div class={styles.container}>
-        <div class={styles.slide}><HomeSlide /></div>
-        {barChartSlides.map(({name, fileUrl, ...additional}) => (
-          <div class={styles.slide}>
-            <BarChartSlide dataFile={fileUrl} title={name} {...additional} />
+      <section
+        class={styles.visualization}
+        aria-label="Census visualization"
+      >
+        <div
+          class={styles.slider}
+          ref={emblaRef}
+        >
+          <div class={styles.container}>
+            <div class={styles.slide}>
+              <HomeSlide />
+            </div>
+
+            {barChartSlides.map(
+              ({
+                name,
+                fileUrl,
+                ...additional
+              }) => (
+                <div class={styles.slide}>
+                  <BarChartSlide
+                    dataFile={fileUrl}
+                    title={name}
+                    {...additional}
+                  />
+                </div>
+              ),
+            )}
           </div>
-        ))}
-      </div>
-      <button class={cn(styles.arrow, styles.next, !canScrollNext() && styles.hide)}
-        onclick={() => emblaApi()?.scrollNext()}>
-        <BsBoxArrowInRight />
-      </button>
-      <button class={cn(styles.arrow, styles.prev, !canScrollPrev() && styles.hide)}
-        onclick={() => emblaApi()?.scrollPrev()}>
-        <BsBoxArrowInLeft />
-      </button>
-    </div>
-    <Show when={!isSmall()}>
-      <nav class={styles.nav}>
-        {allSlides.map(({name: slide}, index) => <>
-            <span class={cn(styles.item, slideIndex() === index && styles.selected)}
-              onclick={() => emblaApi()?.scrollTo(index)}>
-              {slide}
-            </span>
-        </>)}
-      </nav>
-    </Show>
-    <Show when={isSmall()}>
-      <nav class={cn(styles.nav, styles.sliding, !navExpanded() && styles.collapsed)} ref={navEmblaRef}>
-        <div class={styles.container}>
-          {allSlides.map(({name: slide}, index) => <>
-            <span class={cn(styles.item, (!navExpanded() && navIndex() === index) && styles.selected)} onclick={() => {
-              if (navExpanded()) {
-                emblaApi()?.scrollTo(index)
-                navEmblaApi()?.scrollTo(index)
-              }
-              setNavExpanded(!navExpanded())
-            }}>
-              {slide}
-              <Show when={!navExpanded()}>
-                <FaSolidCaretDown class={styles.selectIcon} />
-              </Show>
-            </span>
-          </>)}
         </div>
-      </nav>
-    </Show>
-  </>
+
+        <button
+          class={cn(
+            styles.arrow,
+            styles.prev,
+            !canScrollPrev() &&
+              styles.hide,
+          )}
+          type="button"
+          aria-label="Previous census category"
+          disabled={!canScrollPrev()}
+          onclick={() =>
+            emblaApi()?.scrollPrev()
+          }
+        >
+          <BsBoxArrowInLeft />
+        </button>
+
+        <button
+          class={cn(
+            styles.arrow,
+            styles.next,
+            !canScrollNext() &&
+              styles.hide,
+          )}
+          type="button"
+          aria-label="Next census category"
+          disabled={!canScrollNext()}
+          onclick={() =>
+            emblaApi()?.scrollNext()
+          }
+        >
+          <BsBoxArrowInRight />
+        </button>
+      </section>
+
+      <CategoryRail
+        categories={censusCategories}
+        selectedIndex={slideIndex()}
+        onSelect={selectSlide}
+      />
+
+      <ProjectFooter />
+    </main>
+  )
 }

--- a/src/components/Slider/slider.module.scss
+++ b/src/components/Slider/slider.module.scss
@@ -1,181 +1,122 @@
+.explorer {
+  height: 100dvh;
+  width: 100%;
+
+  display: grid;
+
+  grid-template-rows:
+    auto
+    minmax(0, 1fr)
+    auto
+    auto;
+
+  overflow: hidden;
+
+  background: #111;
+}
+
+.visualization {
+  position: relative;
+
+  min-height: 0;
+
+  overflow: hidden;
+}
+
 .slider {
   height: 100%;
   width: 100%;
+
   overflow: hidden;
+}
 
-  .container {
-    height: 100%;
-    width: 100%;
+.container {
+  height: 100%;
+  width: 100%;
 
-    display: flex;
+  display: flex;
+}
+
+.slide {
+  flex: 0 0 100%;
+
+  min-width: 0;
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.arrow {
+  $size: 4rem;
+
+  position: absolute;
+
+  top: calc(50% - #{$size} / 2);
+
+  z-index: 4;
+
+  height: $size;
+  width: $size;
+
+  appearance: none;
+
+  border: none;
+
+  background-color: transparent;
+
+  filter: drop-shadow(
+    0 2px 2px #111
+  );
+
+  font-size: 2rem;
+
+  color: currentColor;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  transition:
+    transform .2s ease,
+    opacity .2s ease;
+
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    transform: scale(1.1);
   }
 
-  .slide {
-    flex: 0 0 100%;
-    min-width: 0;
+  &.hide,
+  &:disabled {
+    opacity: 0;
 
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    pointer-events: none;
   }
 
-  .arrow {
-    $size: 4rem;
-    position: absolute;
-    top: calc(50% - #{$size} / 2);
+  &.next {
+    right: 2rem;
+  }
 
-    height: $size;
-    width: $size;
+  &.prev {
+    left: 2rem;
+  }
 
-    appearance: none;
-    border: none;
-    background-color: transparent;
-    filter: drop-shadow(0 2px 2px #111);
-    font-size: 2rem;
-    color: currentColor;
-
-    border-radius: 50%;
-    //background-repeat: no-repeat;
-    //background-image: url('../../images/arrow.svg');
-    //background-size: $size * .9;
-    //background-position: center;
-
-    //font-size: 0;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    $hover-scale: scale(1.1);
-    $margin: 2rem;
-    $margin-md: 0rem;
-
-    transition: transform .2s ease;
-    cursor: pointer;
-
-    &.hide {
-      // hide but keep capturing pointer events area to prevent weird behaviour while spamming the button
-      opacity: 0;
-      cursor: default;
-    }
-
-    &:hover {
-      transform: $hover-scale;
-    }
-
+  @media screen and (max-width: 1200px) {
     &.next {
-      right: $margin;
+      right: 0;
     }
 
     &.prev {
-      left: $margin;
-    }
-
-    @media screen and (max-width: 1200px) {
-      &.next {
-        right: $margin-md;
-      }
-
-      &.prev {
-        left: $margin-md;
-      }
-    }
-  }
-
-  @media screen and (max-width: 700px) {
-    .arrow {
-      display: none;
+      left: 0;
     }
   }
 }
 
-.nav {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-
-  padding: 1rem 10%;
-  box-sizing: border-box;
-  background-color: inherit;
-  font-family: 'Archivo', sans-serif;
-
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-
-  &.sliding {
-    height: 12rem;
-    padding: .5rem 10%;
-
-    background: transparentize(#111, .5);
-    backdrop-filter: blur(10px);
-
-    overflow: hidden;
-    display: block;
-
-    transition: .3s ease;
-    transition-property: transform, background, backdrop-filter;
-
-    &.collapsed {
-      transform: translateY(#{(12rem * 0.5) - (3rem * 0.5)});
-      background: transparentize(#111, 1);
-      backdrop-filter: blur(0px);
-
-      .item:not(.selected) {
-        opacity: 0 !important;
-        pointer-events: none;
-      }
-
-      .item.selected {
-        opacity: 1;
-
-        &:after {
-          content: none;
-        }
-      }
-    }
-
-    .container {
-      height: 100%;
-
-      display: flex;
-      flex-direction: column;
-      align-items: stretch;
-      flex-wrap: nowrap;
-      gap: 0;
-    }
-
-    .item {
-      padding: .5rem;
-      height: 3rem;
-      box-sizing: border-box;
-      text-align: center;
-      --scale: 1;
-      transform: rotate(0.001deg) scale(1);
-      will-change: transform;
-      transition: opacity .1s ease;
-    }
-  }
-
-  .item {
-    position: relative;
-    cursor: pointer;
-
-    &.selected:after {
-      content: '';
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 3px;
-      background: transparentize(#ff1f50, .5);
-    }
-
-    .selectIcon {
-      margin-left: .2rem;
-      font-size: .8em;
-    }
+@media screen and (max-width: 700px) {
+  .arrow {
+    display: none;
   }
 }

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,56 @@
+declare module '*.module.scss' {
+  const classes: Readonly<Record<string, string>>
+  export default classes
+}
+
+declare module '*.scss'
+
+declare module '*.csv' {
+  const url: string
+  export default url
+}
+
+declare module '*.svg' {
+  const url: string
+  export default url
+}
+
+declare module '*.png' {
+  const url: string
+  export default url
+}
+
+declare module '*.jpg' {
+  const url: string
+  export default url
+}
+
+declare module '*.webp' {
+  const url: string
+  export default url
+}
+
+declare module '*.mp3' {
+  const url: string
+  export default url
+}
+
+declare module '*.txt' {
+  const url: string
+  export default url
+}
+
+declare module '*.ttf' {
+  const url: string
+  export default url
+}
+
+declare module '*.woff' {
+  const url: string
+  export default url
+}
+
+declare module '*.woff2' {
+  const url: string
+  export default url
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,29 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "sourceMap": true,
-    "allowJs": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
-    "moduleResolution": "node",
+
+    "allowJs": true,
+    "noEmit": true,
+    "isolatedModules": true,
+
     "esModuleInterop": true,
-    "rootDir": "src",
+    "allowSyntheticDefaultImports": true,
+
+    "strict": true,
     "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strictNullChecks": true
-  }
+
+    "rootDir": "src",
+
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "docs"]
 }


### PR DESCRIPTION
## Summary

Hi! I originally forked the project to get it running locally and work through some dependency/security and development-workflow issues, and that grew into a Census Explorer UI update.

I tried to keep the work aligned with the existing project rather than rewriting it. SolidJS, esbuild, SCSS, Embla, Chart.js, the existing visual style, and the underlying census presentation are all retained.

I also noticed you were actively adding the August 2026 census data while I was preparing this, so I rebuilt the proposed changes on top of the latest upstream `main`. The new 2026 census data, Political Activism / Housing / Discovery polls, ethnicity source change, age-color changes, and latest chart-scale fixes are preserved rather than replaced.

## What changed

### Dependency and security maintenance

- Updated outdated/vulnerable dependencies without using forced breaking upgrades.
- Updated the esbuild/Sass toolchain.
- Added TypeScript as an explicit development dependency.
- Regenerated the dependency lockfile.
- Reached `npm audit` with 0 reported vulnerabilities.

### Development workflow

- Expanded the existing custom esbuild setup instead of replacing it.
- Added a real `npm run dev` workflow.
- Added esbuild watch/rebuild behavior.
- Added local serving at `127.0.0.1:8000`.
- Added browser live reload.
- Added development source maps.
- Kept production minification and tree shaking.
- Added `npm run typecheck`.

### TypeScript

- Modernized the TypeScript configuration for the existing SolidJS/esbuild architecture.
- Added strict type checking.
- Added asset declarations for SCSS, CSV, SVG, images, fonts, text, and audio imports already handled by esbuild.

### Census Explorer

- Added a persistent Explorer header using the existing HasanAbi Census artwork.
- Added a custom category dropdown.
- Added stable machine-readable census category IDs.
- Renamed `Cover` to `Home`.
- Replaced the large wrapped category navigation with a horizontally scrollable Embla category rail.
- Kept the main carousel, header dropdown, and category rail synchronized.
- Added responsive behavior for narrower layouts.
- Added a footer crediting the original project.

### Visualization layout

- Preserved the existing stacked Chart.js visualizations.
- Removed legacy spacing that assumed the old bottom navigation layout.
- Updated chart sizing to use the actual available visualization container.
- Added `ResizeObserver`-based sizing so the Explorer header, category rail, footer, titles, and notes can coexist without pushing charts outside the viewport.

### Repository hygiene

- Expanded `.gitignore` for common local development artifacts.
- Preserved upstream's newer decision to ignore generated `docs/` output.
- Generated build files are not included in this PR.

## August 2026 upstream changes preserved

This branch was built on the current upstream code rather than applying the older fork state over it.

In particular, this keeps:

- the August 2026 census data
- `ethnicity.csv` as the current ethnicity source
- the updated Age colors through `colorsAge`
- Political Activism
- Housing
- Discovery
- the latest upstream Chart.js 0–100% scale behavior

The three new categories are also integrated into the Explorer category model with stable IDs:

```txt
political-activism
housing
discovery
```

I am not claiming the new August 2026 census data or those new polls as part of my contribution; those are upstream work that this branch intentionally preserves.

## Contribution documentation

I included `CONTRIBUTION_BREAKDOWN.md` to document the boundary between:

- original upstream work
- newer upstream changes preserved during reconciliation
- modernization/tooling work
- Census Explorer UI work
- possible future ideas that are not implemented yet

The goal is to make authorship and scope explicit rather than blur the original project and the contribution together.

## Validation

The reconciled branch passes:

```bash
git diff --cached --check
npm run typecheck
npm run build
```

The dependency audit also reached:

```bash
found 0 vulnerabilities
```

Development testing has also included the Home view, chart categories, custom dropdown, category rail, keyboard navigation, responsive layouts, and chart resizing.

## Scope

This intentionally does **not** migrate the project to a different application stack.

It does not introduce:

- React
- Next.js
- Vite
- Tailwind
- shadcn
- a new router
- a replacement visualization library

The current visualization mode is still the existing Snapshot-style stacked census chart.

Ideas such as Trend, Change, Compare, timeline controls, and URL-based view state are documented as possible future work but are **not implemented in this PR**.

## Attribution

The original HasanAbi Census project, census data work, visual design, and core visualization concept remain credited to @brilliantdrink.

The modernization, security/development workflow work, TypeScript improvements, responsive-layout changes, and Census Explorer interface are the changes contributed here.

If you'd rather have the tooling/security portion and Explorer UI separated into smaller PRs, I'm happy to split them.